### PR TITLE
Add missing lib and test folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "transform"
   ],
   "files": [
-    "index.js"
+    "index.js",
+    "lib",
+    "test"
   ],
   "author": "Kyle Robinson Young <kyle@dontkry.com> (http://dontkry.com)",
   "license": "MIT",


### PR DESCRIPTION
Hey,

the version `2.0.0` is not working, because the `lib` folder is not included in the tar on npm. I added this to the package.json together with the test folder which might be helpful to some people.

Best,
Finn
