### PR TITLE
Fail gracefully on syntax errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,9 +47,14 @@ module.exports = function yoYoify (file, opts) {
     bufs.push(buf)
     next()
   }
-  function end () {
+  function end (cb) {
     var src = Buffer.concat(bufs).toString('utf8')
-    var res = falafel(src, { ecmaVersion: 6 }, walk).toString()
+    var res
+    try {
+      res = falafel(src, { ecmaVersion: 6 }, walk).toString()
+    } catch (err) {
+      return cb(err)
+    }
     this.push(res)
     this.push(null)
   }

--- a/test/index.js
+++ b/test/index.js
@@ -106,6 +106,25 @@ test('choo and friends', function (t) {
   })
 })
 
+test('emits error for syntax error', function (t) {
+  var src = `var bel = require('bel')
+  module.exports = function (data) {
+    var className = ('test' + ) // <--- HERE'S A SYNTAX ERROR
+    return bel\`<div class="\${className}">
+      <h1>\${data}</h1>
+    </div>\`
+  }`
+  fs.writeFileSync(FIXTURE, src)
+  var b = browserify(FIXTURE, {
+    browserField: false,
+    transform: path.join(__dirname, '..')
+  })
+  b.bundle(function (err, src) {
+    t.ok(err)
+    t.end()
+  })
+})
+
 test('onload/onunload', function (t) {
   t.plan(4)
   var src = `var bel = require('bel')


### PR DESCRIPTION
Without this patch, syntax errors in the source led to a thrown error in
acorn (via falafel) would cause an uncaught error, leading to
inconveniences like a watch/reload dev server (e.g. budo) crashing
if you save a file w/ syntax errors
