### PR TITLE
Fix crash on encountering import/export syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function yoYoify (file, opts) {
     var src = Buffer.concat(bufs).toString('utf8')
     var res
     try {
-      res = falafel(src, { ecmaVersion: 6, sourceType: 'module' }, walk).toString()
+      res = falafel(src, { ecmaVersion: 6, allowImportExportEverywhere: true }, walk).toString()
     } catch (err) {
       return cb(err)
     }

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function yoYoify (file, opts) {
     var src = Buffer.concat(bufs).toString('utf8')
     var res
     try {
-      res = falafel(src, { ecmaVersion: 6 }, walk).toString()
+      res = falafel(src, { ecmaVersion: 6, sourceType: 'module' }, walk).toString()
     } catch (err) {
       return cb(err)
     }


### PR DESCRIPTION
This fix addresses #30 as a step toward supporting `import`/`export` syntax.

While it doesn't update yo-yoify's transformer to support this syntax, it allows codebases that use ES6 style modules to use it without crashing.

The current version will crash with:
```
SyntaxError: 'import' and 'export' may appear only with 'sourceType: module'
```

To other users interested in using this transform with ES6 modules, this change will allow a stopgap solution which is to use `import` statements, but switch to `require` when using a yo-yoify supported function like `choo/html`.