### PR TITLE
Add missing g tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ var SVG_TAGS = [
   'feMorphology', 'feOffset', 'fePointLight', 'feSpecularLighting',
   'feSpotLight', 'feTile', 'feTurbulence', 'filter', 'font', 'font-face',
   'font-face-format', 'font-face-name', 'font-face-src', 'font-face-uri',
-  'foreignObject', 'glyph', 'glyphRef', 'hkern', 'image', 'line',
+  'foreignObject', 'g', 'glyph', 'glyphRef', 'hkern', 'image', 'line',
   'linearGradient', 'marker', 'mask', 'metadata', 'missing-glyph', 'mpath',
   'path', 'pattern', 'polygon', 'polyline', 'radialGradient', 'rect',
   'set', 'stop', 'switch', 'symbol', 'text', 'textPath', 'title', 'tref',


### PR DESCRIPTION
The difference between `SVG_TAGS` array in bel and yo-yoify is the missing g tag in the yo-yoify, which is causing the g tag to be not recognised/rendered in the browser (Chrome), even though its visible in the inspector. I found it was [added to bel in this commit](https://github.com/shama/bel/commit/9fa42e53a00b2558e2d8dc2562f72f356e1dea7e).

Could this list (and some logic) maybe be stored in a shared module of some sort?