### PR TITLE
Add <g> SVG tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ var SVG_TAGS = [
   'feMorphology', 'feOffset', 'fePointLight', 'feSpecularLighting',
   'feSpotLight', 'feTile', 'feTurbulence', 'filter', 'font', 'font-face',
   'font-face-format', 'font-face-name', 'font-face-src', 'font-face-uri',
-  'foreignObject', 'glyph', 'glyphRef', 'hkern', 'image', 'line',
+  'foreignObject', 'g', 'glyph', 'glyphRef', 'hkern', 'image', 'line',
   'linearGradient', 'marker', 'mask', 'metadata', 'missing-glyph', 'mpath',
   'path', 'pattern', 'polygon', 'polyline', 'radialGradient', 'rect',
   'set', 'stop', 'switch', 'symbol', 'text', 'textPath', 'title', 'tref',


### PR DESCRIPTION
I have a source element that looks like this;
```javascript
const view = html`
  <svg preserveAspectRatio="xMidYMid meet" viewBox="0 0 430 150">
    <g transform="translate(0,150) scale(0.1,-0.1)">
      <path d=${c1}/>
    </g>
  </svg>
`;
```
After yo-yoifying, this ends up as
```javascript
var bel5 = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
bel5.setAttributeNS(null, 'preserveAspectRatio', 'xMidYMid meet');
bel5.setAttributeNS(null, 'viewBox', '0 0 430 150');
var bel4 = document.createElement('g');
bel4.setAttribute('transform', 'translate(0,150) scale(0.1,-0.1)');
var bel2 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
bel2.setAttributeNS(null, 'd', arguments[2]);
```
Which doesn't render in either my Chrome nor Firefox, probably because of the `setAttribute` within a NS'ed element.

What's the source of the `SVG_TAGS` list?

Comparing with the [Element Index over at W3](https://www.w3.org/TR/SVG/eltindex.html), I get the following list of missing elements:
```bash
$ grep -v -F -x -f in-yo-yoify in-w3-index                                                                                                                      
a
g
script
style
```

With the current logic, adding `a`,`script`, and `style` to the `SVG_TAGS` list might cause trouble for people using those tags outside of an `<svg>`, but I guess the `g` should be safe to add.