### PR TITLE
Use updated acorn parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var path = require('path')
 var falafel = require('falafel')
 var through = require('through2')
 var hyperx = require('hyperx')
+var acorn = require('acorn')
 
 var SUPPORTED_VIEWS = ['bel', 'yo-yo', 'choo', 'choo/html']
 var DELIM = '~!@|@|@!~'
@@ -52,7 +53,7 @@ module.exports = function yoYoify (file, opts) {
     var src = Buffer.concat(bufs).toString('utf8')
     var res
     try {
-      res = falafel(src, { ecmaVersion: 6 }, walk).toString()
+      res = falafel(src, { ecmaVersion: 8, parser: acorn }, walk).toString()
     } catch (err) {
       return cb(err)
     }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/shama/yo-yoify",
   "dependencies": {
+    "acorn": "^5.0.0",
     "falafel": "^2.0.0",
     "hyperx": "^2.0.3",
     "on-load": "^3.2.0",

--- a/test/index.js
+++ b/test/index.js
@@ -160,7 +160,7 @@ test('onload/onunload', function (t) {
   })
 })
 
-test.skip('works with newer js', function (t) {
+test('works with newer js', function (t) {
   t.plan(1)
   var src = 'const bel = require(\'bel\')\n async function whatever() {\n return bel`<div>yep</div>`\n }' // eslint-disable-line
   fs.writeFileSync(FIXTURE, src)


### PR DESCRIPTION
`falafel`'s dependency of acorn is outdated, but it lets us pass in our own version. This allows yo-yoify to support newer syntax features like async/await.

Fixes #34 