### PR TITLE
Use bel/appendChild, closes #49

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ When using Browserify, use as a global transform:
 browserify entry.js -g yo-yoify -o bundle.js
 ```
 
+Also make sure to install bel v5.1.3 or up as a direct dependency. Its
+`bel/appendChild` export is used in transformed output.
+
 ## how this works
 
 `yo-yo` and `bel`, without this transform, pass template literals to `hyperx`.

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ var SVG_TAGS = [
 
 module.exports = function yoYoify (file, opts) {
   if (/\.json$/.test(file)) return through()
+
   var bufs = []
   var viewVariables = []
   return through(write, end)
@@ -222,7 +223,7 @@ function processNode (node) {
     var params = resultArgs.join(',')
 
     node.parent.update('(function () {\n      ' +
-      '\n      var ac = require(\'' + path.resolve(__dirname, 'lib', 'appendChild.js').replace(/\\/g, '\\\\') + '\')' + // fix Windows paths
+      '\n      var ac = require(\'bel/appendChild\')' +
       '\n      var sa = require(\'' + path.resolve(__dirname, 'lib', 'setAttribute.js').replace(/\\/g, '\\\\') + '\')' + // fix Windows paths
       '\n      ' + src[0].src + '\n      return ' + src[0].name + '\n    }(' + params + '))')
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "through2": "^2.0.1"
   },
   "devDependencies": {
-    "bel": "^4.3.2",
+    "bel": "^5.1.3",
     "browserify": "^14.1.0",
     "choo": "^5.0.4",
     "standard": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
   "homepage": "https://github.com/shama/yo-yoify",
   "dependencies": {
     "acorn": "^5.0.0",
+    "bel": "^5.1.3",
     "falafel": "^2.0.0",
     "hyperx": "^2.0.3",
     "on-load": "^3.2.0",
     "through2": "^2.0.1"
   },
   "devDependencies": {
-    "bel": "^5.1.3",
     "browserify": "^14.1.0",
     "choo": "^5.0.4",
     "standard": "^9.0.2",


### PR DESCRIPTION
And closes #53

This uses the `bel/appendChild` export introduced by bel v5.1.3.
<strike>It's breaking because now you have to have bel installed.</strike>