### PR TITLE
Compile already-compiled template strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,12 @@
     "through2": "^2.0.1"
   },
   "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+    "babelify": "^8.0.0",
     "bel": "^4.3.2",
     "browserify": "^14.1.0",
+    "bubleify": "^1.0.0",
     "choo": "^5.0.4",
     "standard": "^9.0.2",
     "tape": "^4.5.1",

--- a/test/index.js
+++ b/test/index.js
@@ -169,3 +169,54 @@ test('boolean attribute expression', function (t) {
     t.end()
   })
 })
+
+test('babel-compiled template literals', function (t) {
+  t.plan(3)
+  fs.writeFileSync(FIXTURE, `
+    var bel = require('bel')
+
+    bel\`<div class="whatever \${abc}">\${xyz}</div>\`
+  `)
+  var b = browserify(FIXTURE, {
+    transform: [
+      ['babelify', {
+        plugins: ['transform-es2015-template-literals']
+      }],
+      path.join(__dirname, '..')
+    ]
+  })
+  b.bundle(function (err, src) {
+    fs.unlinkSync(FIXTURE)
+    t.ifError(err)
+    t.ok(src.indexOf('document.createElement("div")') !== -1, 'created a tag')
+    t.ok(src.indexOf('<div') === -1, 'removed template literal parts values')
+    t.end()
+  })
+})
+
+test('buble-compiled template literals', function (t) {
+  t.plan(2)
+
+  fs.writeFileSync(FIXTURE, `
+    var bel = require('bel')
+
+    bel\`<div class="whatever \${abc}">\${xyz}</div>\`
+  `)
+
+  var b = browserify(FIXTURE, {
+    transform: [
+      ['bubleify', {
+        transforms: {
+          dangerousTaggedTemplateString: true
+        }
+      }],
+      path.join(__dirname, '..')
+    ]
+  })
+  b.bundle(function (err, src) {
+    fs.unlinkSync(FIXTURE)
+    t.ifError(err)
+    t.ok(src.indexOf('document.createElement("div")') !== -1, 'created a tag')
+    t.end()
+  })
+})


### PR DESCRIPTION
This patch allows yo-yoify to also pick up template strings that were
already compiled by an earlier build step, currently either Babel or
Bublé. This way you don't have to disable the template strings transform
when using Babel, which can be a big pain.

Babel compiles template strings in quite a complex way to keep with the
spec. The literal parts of a template string are assigned to a variable
first, and that variable is passed to the compiled template tag function
call. So this patch detects `_taggedTemplateLiteral` helper calls and
takes the template string literal parts from those.

Eg, with input:

```js
var bel = require('bel')

bel`<div class="whatever ${abc}">${xyz}</div>`
```

For Babel:

```js
// Babelified code:
var _templateObject = _taggedTemplateLiteral(['<div class="whatever ', '">', '</div>'], ['<div class="whatever ', '">', '</div>']);

function _taggedTemplateLiteral(strings, raw) { return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }

var bel = require('bel');

bel(_templateObject, abc, xyz);
```
becomes:
```js
var _templateObject = 0;

function _taggedTemplateLiteral(strings, raw) { return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }

var bel = {};

(function () {

  var ac = require('/app/yo-yoify/lib/appendChild.js')
  var sa = require('/app/yo-yoify/lib/setAttribute.js')
  var bel0 = document.createElement("div")
bel0.setAttribute("class", "whatever " + arguments[0])
ac(bel0, [arguments[1]])
  return bel0
}(abc,xyz));

```

For Bublé:

```js
// post-Bublé code:
var bel = require('bel')

bel(["<div class=\"whatever ", "\">", "</div>"], abc, xyz)
```
becomes:
```js
var bel = {}

(function () {

  var ac = require('/app/yo-yoify/lib/appendChild.js')
  var sa = require('/app/yo-yoify/lib/setAttribute.js')
  var bel0 = document.createElement("div")
bel0.setAttribute("class", "whatever " + arguments[0])
ac(bel0, [arguments[1]])
  return bel0
}(abc,xyz))
```