### PR TITLE
add source maps, closes #39

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,11 @@
   "homepage": "https://github.com/shama/yo-yoify",
   "dependencies": {
     "acorn": "^5.0.0",
-    "falafel": "^2.0.0",
+    "convert-source-map": "^1.5.1",
     "hyperx": "^2.0.3",
     "on-load": "^3.2.0",
-    "through2": "^2.0.1"
+    "through2": "^2.0.1",
+    "transform-ast": "^2.2.1"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/test/index.js
+++ b/test/index.js
@@ -220,3 +220,56 @@ test('buble-compiled template literals', function (t) {
     t.end()
   })
 })
+
+test('generates source maps in debug mode', function (t) {
+  t.plan(2)
+  fs.writeFileSync(FIXTURE, `
+    var html = require('bel')
+    var el = html\`<span>title</span>\`
+    html\`
+      <header>
+        <h2>\${el}</h2>
+      </header>
+    \`
+  `)
+
+  var b = browserify(FIXTURE, {
+    debug: true,
+    transform: path.join(__dirname, '..')
+  })
+  b.bundle(function (err, src) {
+    fs.unlinkSync(FIXTURE)
+    t.ifError(err)
+    t.ok(src.indexOf('//# sourceMappingURL=') !== -1, 'has source map')
+    t.end()
+  })
+})
+
+test('accepts input source maps in debug mode', function (t) {
+  t.plan(2)
+  fs.writeFileSync(FIXTURE, `
+    var html = require('bel')
+    var el = html\`<span>title</span>\`
+    html\`
+      <header>
+        <h2>\${el}</h2>
+      </header>
+    \`
+  `)
+
+  var b = browserify(FIXTURE, {
+    debug: true,
+    transform: [
+      ['babelify', {
+        plugins: ['transform-es2015-template-literals']
+      }],
+      path.join(__dirname, '..')
+    ]
+  })
+  b.bundle(function (err, src) {
+    fs.unlinkSync(FIXTURE)
+    t.ifError(err)
+    t.ok(src.indexOf('//# sourceMappingURL=') !== -1, 'has source map')
+    t.end()
+  })
+})


### PR DESCRIPTION
transform-ast is similar to falafel but generates source maps using magic-string. if the input source code already contains a source map, the generated source map takes that into account and maps back to the original source.

with babelify + yo-yoify, using https://sokra.github.io/source-map-visualization:

![image](https://user-images.githubusercontent.com/1006268/33336354-ec8e1c68-d46f-11e7-8367-c0fdc9c855b1.png)

it maps back mooostly to the correct places--some things aren't perfect, for example if you have a big inline function

```js
html`
  <div onclick=${function () {
    throw Error('xyz')
  } />
`
```

it is not mapped individually, so you only know that the error was thrown somewhere in the template string.

that's still better than the current situation though, because not doing source maps at all means other transforms's source maps will be thrown off by N lines, and then errors would be pointing to the wrong thing entirely.